### PR TITLE
Do not flag line length for test descriptions

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -17,7 +17,7 @@ Naming/VariableNumber:
 # ============== Layout ==============
 Layout/LineLength:
   Max: 100
-  AllowedPatterns: ['(\A|\s)#']
+  AllowedPatterns: [(\A|\s)(#|test|it|describe)]
 
 # ============== Metrics ==============
 Metrics/BlockLength:


### PR DESCRIPTION
## Background

Sometimes, I need to write a description of the test that does not fit into 100 chars long, for example

```ruby
it 'removes the user from their primary team, but not from other secondary teams, when the feature toggle `the_feature` is on' do
   ...
end
```

and it's annoying that it gets flagged with "line too long"

## Proposal

Do not flag line length for test descriptions

## Before

<img width="1182" alt="Screenshot 2024-01-11 at 17 46 10" src="https://github.com/learnamp/learnamp-style-guides/assets/1259814/0a53a7b4-0a4d-40b5-8da3-a75f3c39bdda">


## After

<img width="1106" alt="Screenshot 2024-01-11 at 17 45 13" src="https://github.com/learnamp/learnamp-style-guides/assets/1259814/2df0d423-fbd3-4668-bb41-aad5d15e27de">
