### PR TITLE
Enable `ExpectMatchingDefinition` on `Naming/FileName`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -14,6 +14,9 @@ Naming/VariableNumber:
   Exclude:
   - test/**/*.rb
 
+Naming/FileName:
+  ExpectMatchingDefinition: true
+
 # ============== Layout ==============
 Layout/LineLength:
   Max: 100


### PR DESCRIPTION
To actually prevent this silliness https://github.com/learnamp/learnamp/pull/13787