### PR TITLE
Exclude Matching Def cop on Units tests

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -16,6 +16,9 @@ Naming/VariableNumber:
 
 Naming/FileName:
   ExpectMatchingDefinition: true
+  Exclude:
+  - test/units/**/*.rb
+  - test/shared_assertions/**/*.rb
 
 # ============== Layout ==============
 Layout/LineLength:


### PR DESCRIPTION
This is causing multiple issues on Units test and shared test.

And I can't modify shared tests just for the sake of this rule as it would break/require changes in all tests.