### PR TITLE
Ignore rake files for Naming/FileName checks

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -19,6 +19,7 @@ Naming/FileName:
   Exclude:
   - test/units/**/*.rb
   - test/shared_assertions/**/*.rb
+  - lib/tasks/**/*.rake
 
 # ============== Layout ==============
 Layout/LineLength:


### PR DESCRIPTION
![image](https://github.com/learnamp/learnamp-style-guides/assets/2847493/0c908e06-759f-49fe-9f77-1e5ff3322a39)

AC
- [x] Exclude `lib/tasks/**/*.rake` from Naming/FileName checks