### PR TITLE
Remove Naming/FileName for *.rb in test/lib/tasks/

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -20,6 +20,7 @@ Naming/FileName:
   - test/units/**/*.rb
   - test/shared_assertions/**/*.rb
   - lib/tasks/**/*.rake
+  - test/lib/tasks/**/*.rb
 
 # ============== Layout ==============
 Layout/LineLength:


### PR DESCRIPTION
![image](https://github.com/learnamp/learnamp-style-guides/assets/2847493/e2baa473-b4b4-4c18-90fb-2d0b6561d755)

Rake test files expect `Tasks::TestFile` when `/lib/tasks/testfile.rb` is defined, whereas we would not supply the `Tasks` namespace in this instance