### PR TITLE
Disable rubocop Lint/SymbolConversion

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -26,6 +26,10 @@ Layout/LineLength:
   Max: 100
   AllowedPatterns: [(\A|\s)(#|test|it|describe)]
 
+# ============== Lint ==============
+Lint/SymbolConversion:
+  Enabled: false
+
 # ============== Metrics ==============
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
Disable rubocop Lint/SymbolConversion

## Why
We have this as a warning in case you edit old files, and people would usually go and fix them, but we have agreed for the rule to be removed as it looks generally worse than using to_sym.