### PR TITLE
`rubocop-minitest` config update

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,5 +1,7 @@
-require:
+plugins:
   - rubocop-minitest
+
+require:
   - rubocop-rails
   - rubocop-performance
   - rubocop-rake


### PR DESCRIPTION
A follow up of updating `rubocop-minitest` https://github.com/learnamp/learnamp/pull/16804, we also need to update the config